### PR TITLE
profile restricted in size

### DIFF
--- a/client/src/components/create-page/CreateProfile.css
+++ b/client/src/components/create-page/CreateProfile.css
@@ -29,6 +29,8 @@
 .create-profile-image {
   border: var(--border-blue) 3px solid;
   height: 9em;
+  width: 9rem;
+  object-fit: cover;
   border-radius: 50%;
   justify-self: center;
   align-items: center;

--- a/client/src/components/profile-page/Profile.css
+++ b/client/src/components/profile-page/Profile.css
@@ -28,6 +28,9 @@
   object-fit: contain;
   object-position: center;
   border-radius: 50%;
+  height: 12rem;
+  width: 12rem;
+  object-fit: cover;
 }
 .top-wrapper-icons {
   display: flex;


### PR DESCRIPTION
Heyo! Fixed my issue with the profile picture, whereby beforehand people couldnt use their images if they werent a square, they would appear obscure and mis-shaped.

- Restrited the sizing of profile pictures used by organic users.